### PR TITLE
updated versions, properties, docker images

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-javaspring-deploy.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-deploy.yml
@@ -24,7 +24,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: amido/stacks-pipeline-templates
+      name: Ensono/stacks-pipeline-templates
       ref: feature/cycle9
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
@@ -33,14 +33,14 @@ resources:
   containers:
     # Container for Java Build and Testing
     - container: azul_java
-      image: amidostacks/runner-pwsh-java:0.3.94-main
+      image: amidostacks/runner-pwsh-java:0.4.48-stable
     # Container for inlining Jacoco assets as Azure DevOps strips them
     # https://github.com/microsoft/azure-pipelines-tasks/issues/3027
     - container: node
       image: amidostacks/node-14:0.0.1
     # Container for Sonar Scanner
     - container: sonar_scanner
-      image: amidostacks/ci-sonarscanner:0.0.2
+      image: amidostacks/runner-pwsh-dotnet:0.4.51-stable
     # Container for Kubernetes Deployment
     - container: k8s_deploy
       image: amidostacks/ci-k8s:0.0.12

--- a/build/azDevOps/azure/azure-pipelines-javaspring-deploy.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-deploy.yml
@@ -25,7 +25,7 @@ resources:
     - repository: templates
       type: github
       name: Ensono/stacks-pipeline-templates
-      ref: feature/cycle9
+      ref: feature/cycle4
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -52,7 +52,7 @@ variables:
   - name: version_minor
     value: 0
   - name: version_patch
-    value: 0
+    value: 1
   - name: build_type
     ${{ if eq( variables['Build.SourceBranchName'], 'main' ) }}:
       value: "RELEASE"

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -116,7 +116,7 @@ variables:
 
   # Test
   - name: functional_test
-    value: true
+    value: false
   - name: coverage_test
     value: true
 
@@ -124,7 +124,6 @@ variables:
   - name: vulnerability_scan
     value: true
   - name: vulnerability_scan_report
-    value: "target/dependency-check-report.html"
   - name: vulnerability_scan_fail_build_on_detection
     value: false
 

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -101,7 +101,7 @@ variables:
   - name: maven_surefire_reports_dir
     value: "target/surefire-reports"
   - name: maven_allowed_test_tags
-    value: "Unit | Component | Integration"
+    value: "Unit | Component | Integration | Functional | Performance | Smoke"
   - name: maven_archetype_pom_file
     value: "target/generated-sources/archetype/pom.xml"
   - name: maven_archetype_properties_file

--- a/java/.mvn/jvm.config
+++ b/java/.mvn/jvm.config
@@ -1,0 +1,11 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens java.base/java.text=ALL-UNNAMED
+--add-opens java.desktop/java.awt.font=ALL-UNNAMED

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.amido.stacks.modules</groupId>
     <artifactId>stacks-modules-parent</artifactId>
-    <version>2.0.6-RELEASE</version>
+    <version>2.0.7-RELEASE</version>
   </parent>
 
   <artifactId>stacks-aws-dynamodb</artifactId>
@@ -15,9 +15,9 @@
   <description>Core AWS DynamoDB components for the Java Stacks solution</description>
 
   <properties>
-    <stacks.core.commons.version>2.0.5</stacks.core.commons.version>
+    <stacks.core.commons.version>2.0.7</stacks.core.commons.version>
     <spring.data.dynamodb.version>5.2.5</spring.data.dynamodb.version>
-    <stacks.aws.version>1.0.2</stacks.aws.version>
+    <stacks.aws.version>1.0.3</stacks.aws.version>
   </properties>
 
   <dependencies>
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${io.netty.netty-codec-http.version}</version>
     </dependency>
 
     <!-- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327 -->

--- a/java/sonar-project.properties
+++ b/java/sonar-project.properties
@@ -25,6 +25,6 @@ sonar.java.libraries=.m2
 sonar.junit.reportPaths=target/surefire-reports
 sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
 sonar.language=java
-sonar.java.source=11
+sonar.java.source=17
 sonar.cpd.exclusions=**/domain/*
 sonar.coverage.exclusions=**/domain/**

--- a/java/src/main/java/com/amido/stacks/dynamodb/config/DynamoDBConfig.java
+++ b/java/src/main/java/com/amido/stacks/dynamodb/config/DynamoDBConfig.java
@@ -8,10 +8,12 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConfigurationProperties(prefix = "amazon.dynamodb")
 @EnableDynamoDBRepositories(basePackages = "com.amido.stacks.workloads.menu.repository")
 public class DynamoDBConfig {
 

--- a/java/src/main/java/com/amido/stacks/dynamodb/repository/StacksDynamoDbRepository.java
+++ b/java/src/main/java/com/amido/stacks/dynamodb/repository/StacksDynamoDbRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 
 @NoRepositoryBean
 public interface StacksDynamoDbRepository<T>
-    extends StacksPersistence<T>, CrudRepository<T, String>, PagingAndSortingRepository<T, String> {}
+    extends StacksPersistence<T>,
+        CrudRepository<T, String>,
+        PagingAndSortingRepository<T, String> {}

--- a/java/src/main/java/com/amido/stacks/dynamodb/repository/StacksDynamoDbRepository.java
+++ b/java/src/main/java/com/amido/stacks/dynamodb/repository/StacksDynamoDbRepository.java
@@ -1,9 +1,10 @@
 package com.amido.stacks.dynamodb.repository;
 
 import com.amido.stacks.core.repository.StacksPersistence;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 @NoRepositoryBean
 public interface StacksDynamoDbRepository<T>
-    extends StacksPersistence<T>, PagingAndSortingRepository<T, String> {}
+    extends StacksPersistence<T>, CrudRepository<T, String>, PagingAndSortingRepository<T, String> {}

--- a/java/src/main/java/com/amido/stacks/workloads/menu/repository/MenuRepository.java
+++ b/java/src/main/java/com/amido/stacks/workloads/menu/repository/MenuRepository.java
@@ -11,10 +11,7 @@ import org.springframework.stereotype.Repository;
 @EnableScan
 @EnableScanCount
 @Repository
-public interface MenuRepositoryDynamoDb extends StacksDynamoDbRepository<Menu> {
-
-  @Override
-  Menu save(Menu menu);
+public interface MenuRepository extends StacksDynamoDbRepository<Menu> {
 
   /**
    * Query is constructed OOTB- out of the box, executed and results are fetched based param

--- a/java/src/main/java/com/amido/stacks/workloads/menu/service/impl/DynamoDbMenuQueryService.java
+++ b/java/src/main/java/com/amido/stacks/workloads/menu/service/impl/DynamoDbMenuQueryService.java
@@ -3,7 +3,7 @@ package com.amido.stacks.workloads.menu.service.impl;
 import static org.springframework.data.domain.PageRequest.of;
 
 import com.amido.stacks.workloads.menu.domain.Menu;
-import com.amido.stacks.workloads.menu.repository.MenuRepositoryDynamoDb;
+import com.amido.stacks.workloads.menu.repository.MenuRepository;
 import com.amido.stacks.workloads.menu.service.MenuQueryService;
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +19,7 @@ public class DynamoDbMenuQueryService implements MenuQueryService {
 
   private static final String NAME = "name";
 
-  private final MenuRepositoryDynamoDb menuRepository;
+  private final MenuRepository menuRepository;
 
   @Override
   public Optional<Menu> findById(UUID id) {

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=dynamodb

--- a/java/src/test/java/com/amido/stacks/workloads/menu/service/impl/DynamoDbMenuQueryServiceTest.java
+++ b/java/src/test/java/com/amido/stacks/workloads/menu/service/impl/DynamoDbMenuQueryServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.amido.stacks.workloads.menu.domain.Menu;
 import com.amido.stacks.workloads.menu.domain.utility.MenuHelper;
-import com.amido.stacks.workloads.menu.repository.MenuRepositoryDynamoDb;
+import com.amido.stacks.workloads.menu.repository.MenuRepository;
 import com.amido.stacks.workloads.menu.service.MenuQueryService;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +28,7 @@ class DynamoDbMenuQueryServiceTest {
   @Test
   void findById() {
 
-    MenuRepositoryDynamoDb repository = mock(MenuRepositoryDynamoDb.class);
+    MenuRepository repository = mock(MenuRepository.class);
     MenuQueryService menuQueryServiceImpl = new DynamoDbMenuQueryService(repository);
 
     Menu menu = MenuHelper.createMenu(1);
@@ -46,7 +46,7 @@ class DynamoDbMenuQueryServiceTest {
   @Test
   void findAll() {
 
-    MenuRepositoryDynamoDb repository = mock(MenuRepositoryDynamoDb.class);
+    MenuRepository repository = mock(MenuRepository.class);
     MenuQueryService menuQueryServiceImpl = new DynamoDbMenuQueryService(repository);
 
     Pageable pageable = mock(Pageable.class);
@@ -69,7 +69,7 @@ class DynamoDbMenuQueryServiceTest {
   @Test
   void findAllByRestaurantId() {
 
-    MenuRepositoryDynamoDb repository = mock(MenuRepositoryDynamoDb.class);
+    MenuRepository repository = mock(MenuRepository.class);
     MenuQueryService menuQueryServiceImpl = new DynamoDbMenuQueryService(repository);
 
     Pageable pageable = mock(Pageable.class);
@@ -88,7 +88,7 @@ class DynamoDbMenuQueryServiceTest {
   @Test
   void findAllByNameContaining() {
 
-    MenuRepositoryDynamoDb repository = mock(MenuRepositoryDynamoDb.class);
+    MenuRepository repository = mock(MenuRepository.class);
     MenuQueryService menuQueryServiceImpl = new DynamoDbMenuQueryService(repository);
 
     Pageable pageable = mock(Pageable.class);
@@ -107,7 +107,7 @@ class DynamoDbMenuQueryServiceTest {
   @Test
   void findAllByRestaurantIdAndNameContaining() {
 
-    MenuRepositoryDynamoDb repository = mock(MenuRepositoryDynamoDb.class);
+    MenuRepository repository = mock(MenuRepository.class);
     MenuQueryService menuQueryServiceImpl = new DynamoDbMenuQueryService(repository);
 
     Pageable pageable = mock(Pageable.class);


### PR DESCRIPTION
Renamed to MenuRepository as both dynamodb and cosmosdb have to have the same MenuRepository in order to be used at runtime based on profile. MenuRepository is used in cqrs and cqrs-events projects

I've also updated the configuration to load the properties based on the profile